### PR TITLE
Add @lezer/common to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@lezer/lr": "^1.0.0",
-    "@lezer/highlight": "^1.0.0"
+    "@lezer/highlight": "^1.0.0",
+    "@lezer/common": "^1.0.0"
   },
   "repository": {
     "type" : "git",


### PR DESCRIPTION
In https://github.com/lezer-parser/html/blob/main/src/content.js you're refering `@lezer/common` but the package isn't included in the package.json.