### PR TITLE
Align HTML parsing with spec to support Vue Templates and Single File Components

### DIFF
--- a/src/html.grammar
+++ b/src/html.grammar
@@ -136,8 +136,8 @@ Comment { commentStart commentContent* commentEnd }
   identifier { nameStart nameChar* }
 
   TagName { identifier }
-  
-  AttributeName { identifier }
+
+  AttributeName { ![\u0000-\u0020\u007F-\u009F"'>/=\uFDD0-\uFDEF\uFFFE\uFFFF]+ }
 
   UnquotedAttributeValue { ![ \t\n\r\u00a0=<>"'/]+ }
 

--- a/src/html.grammar
+++ b/src/html.grammar
@@ -35,7 +35,8 @@ TextareaText[group="TextContent Entity"] { textareaText* }
   }
 
   SelfClosingTag {
-    StartSelfClosingTag TagName Attribute* EndTag
+    StartSelfClosingTag TagName Attribute* "/"? EndTag |
+    StartTag TagName Attribute* "/" EndTag
   }
 
   MismatchedCloseTag {
@@ -121,7 +122,7 @@ Comment { commentStart commentContent* commentEnd }
 }
 
 @tokens {
-  EndTag[openedBy="StartTag StartCloseTag"] { "/"? ">" }
+  EndTag[openedBy="StartTag StartCloseTag"] { ">" }
 
   nameStart {
     ":" | @asciiLetter | "_" |

--- a/test/tags.txt
+++ b/test/tags.txt
@@ -141,6 +141,14 @@ Document(Element(SelfClosingTag(StartTag,TagName,EndTag)))
 
 Document(Element(OpenTag(StartTag,TagName,EndTag)))
 
+# Self closed tag
+
+<p />
+
+==>
+
+Document(Element(SelfClosingTag(StartTag, TagName, EndTag)))
+
 # Nested mismatched tag
 
 <a><b><c></c></x></a>

--- a/test/vue.txt
+++ b/test/vue.txt
@@ -1,0 +1,56 @@
+# Parses Vue builtin directives
+
+<span v-text="msg"></span>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue :is shorthand syntax
+
+<Component :is="view"></Component>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue),EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue @click shorthand syntax
+
+<button @click="handler()">Click me</button>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    Text,
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue @submit.prevent shorthand syntax
+
+<form @submit.prevent="onSubmit"></form>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue Dynamic Arguments
+
+<a v-bind:[attributeName]="url">Link</a>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    Text,
+    CloseTag(StartCloseTag, TagName, EndTag)))

--- a/test/vue.txt
+++ b/test/vue.txt
@@ -17,7 +17,7 @@ Document(
 
 Document(
   Element(
-    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue),EndTag),
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
     CloseTag(StartCloseTag, TagName, EndTag)))
 
 # Parses Vue @click shorthand syntax
@@ -52,5 +52,30 @@ Document(
 Document(
   Element(
     OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    Text,
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue Single File Component templates
+
+<template>
+  <Header />
+  <Main />
+  <router-view />
+</template>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, EndTag),
+    Text,
+    Element(
+      SelfClosingTag(StartTag, TagName, EndTag)),
+    Text,
+    Element(
+      SelfClosingTag(StartTag, TagName, EndTag)),
+    Text,
+    Element(
+      SelfClosingTag(StartTag, TagName, EndTag)),
     Text,
     CloseTag(StartCloseTag, TagName, EndTag)))


### PR DESCRIPTION
Vue Templates and Single File Components are basically valid HTML, so for the purpose of supporting them in Chrome DevTools, it's enough to ensure that we treat `*.vue` files as HTML documents and ensure that the HTML parser is sufficiently relaxed. These patches add support for relaxed attribute name parsing, and also adjust the parsing of self-closing tags to better support common components template syntax.