### PR TITLE
Align attribute token syntax to the HTML spec.

### DIFF
--- a/src/html.grammar
+++ b/src/html.grammar
@@ -136,8 +136,8 @@ Comment { commentStart commentContent* commentEnd }
   identifier { nameStart nameChar* }
 
   TagName { identifier }
-  
-  AttributeName { identifier }
+
+  AttributeName { ![\u0000-\u0020\u007F-\u009F"'>/=\uFDD0-\uFDEF\uFFFE\uFFFF]+ }
 
   UnquotedAttributeValue { ![ \t\n\r\u00a0=<>"'/]+ }
 

--- a/test/vue.txt
+++ b/test/vue.txt
@@ -1,0 +1,56 @@
+# Parses Vue builtin directives
+
+<span v-text="msg"></span>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue :is shorthand syntax
+
+<Component :is="view"></Component>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue),EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue @click shorthand syntax
+
+<button @click="handler()">Click me</button>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    Text,
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue @submit.prevent shorthand syntax
+
+<form @submit.prevent="onSubmit"></form>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    CloseTag(StartCloseTag, TagName, EndTag)))
+
+# Parses Vue Dynamic Arguments
+
+<a v-bind:[attributeName]="url">Link</a>
+
+==>
+
+Document(
+  Element(
+    OpenTag(StartTag, TagName, Attribute(AttributeName, Is, AttributeValue), EndTag),
+    Text,
+    CloseTag(StartCloseTag, TagName, EndTag)))


### PR DESCRIPTION
According to the HTML spec[^1], attribute names can contain a lot more characters. This allows among other things to properly support Vue template syntax[^2], in particular shorthands like `@click=onClick` and also Dynamic Arguments syntax like `v-bind:[attributeName]="url"`.

[^1]: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
[^2]: https://vuejs.org/guide/essentials/template-syntax.html

Bug: http://crbug.com/1383451