### PR TITLE
Align unquoted attribute value syntax with the HTML spec.

### DIFF
--- a/src/html.grammar
+++ b/src/html.grammar
@@ -142,7 +142,7 @@ Comment { commentStart commentContent* commentEnd }
 
   AttributeName { ![\u0000-\u0020\u007F-\u009F"'>/=\uFDD0-\uFDEF\uFFFE\uFFFF]+ }
 
-  UnquotedAttributeValue { ![ \t\n\r\u00a0=<>"'/]+ }
+  UnquotedAttributeValue { ![ \t\n\r\u000C=<>"'\u0060]+ }
 
   attributeContentDouble { !["&]+ }
 

--- a/test/tags.txt
+++ b/test/tags.txt
@@ -61,6 +61,19 @@ Document(Element(OpenTag(StartTag,TagName,
   Attribute(AttributeName,Is,UnquotedAttributeValue),EndTag),
 CloseTag(StartCloseTag,TagName,EndTag)))
 
+# Unquoted attributes with slashes
+
+<link as=font crossorigin=anonymous href=/fonts/google-sans/regular/latin.woff2 rel=preload>
+
+==>
+
+Document(Element(SelfClosingTag(StartTag,TagName,
+  Attribute(AttributeName,Is,UnquotedAttributeValue),
+  Attribute(AttributeName,Is,UnquotedAttributeValue),
+  Attribute(AttributeName,Is,UnquotedAttributeValue),
+  Attribute(AttributeName,Is,UnquotedAttributeValue),
+EndTag)))
+
 # Single-quoted attributes
 
 <link x='one' z='two&amp;'>
@@ -323,7 +336,7 @@ Document(Element(SelfClosingTag(StartTag, TagName, Attribute(AttributeName, Is, 
 
 # Supports self-closing dialect {"dialect": "selfClosing"}
 
-<section><image id=i2/></section>
+<section><image id=i2 /></section>
 
 ==>
 


### PR DESCRIPTION
According to the HTML spec[^1] the unquoted attribute values can contain slashes, and basically only forbid ASCII whitespace, quotation characters, equals, and <>. This fixes the token regex to be aligned with the HTML specification here.

[^1]: https://html.spec.whatwg.org/multipage/syntax.html#unquoted

Bug: https://crbug.com/1385661